### PR TITLE
Task 7

### DIFF
--- a/authorization-service/handler.js
+++ b/authorization-service/handler.js
@@ -1,0 +1,3 @@
+import basicAuthorizer from "./handlers/basicAuthorizer.js";
+
+export { basicAuthorizer };

--- a/authorization-service/handlers/basicAuthorizer.js
+++ b/authorization-service/handlers/basicAuthorizer.js
@@ -1,0 +1,46 @@
+export default (event, context, callback) => {
+  const token = event.authorizationToken;
+  const b64Creds = token.split(" ")[1];
+
+  if (event["type"] !== "TOKEN" || !b64Creds) {
+    callback("Unauthorized"); // Return a 401 Unauthorized response
+  }
+  try {
+    const creds = Buffer.from(b64Creds, "base64").toString("utf-8").split(":");
+    const userName = creds[0];
+    const password = creds[1];
+
+    console.log(`userName ${userName}, password ${password}`);
+
+    const storedPassword = process.env[userName];
+
+    const effect =
+      !storedPassword || storedPassword !== password ? "Deny" : "Allow";
+
+    const policy = generatePolicy(b64Creds, effect, event.methodArn);
+
+    callback(null, policy);
+  } catch (e) {
+    callback(`Unauthorized ${e.message}`);
+  }
+};
+
+// Help function to generate an IAM policy
+const generatePolicy = function (principalId, effect, resource) {
+  const authResponse = {};
+
+  authResponse.principalId = principalId;
+  if (effect && resource) {
+    const policyDocument = {};
+    policyDocument.Version = "2012-10-17";
+    policyDocument.Statement = [];
+    const statementOne = {};
+    statementOne.Action = "execute-api:Invoke";
+    statementOne.Effect = effect;
+    statementOne.Resource = resource;
+    policyDocument.Statement[0] = statementOne;
+    authResponse.policyDocument = policyDocument;
+  }
+
+  return authResponse;
+};

--- a/authorization-service/serverless.yml
+++ b/authorization-service/serverless.yml
@@ -1,0 +1,41 @@
+service: authorization-service
+frameworkVersion: "3"
+
+provider:
+  name: aws
+  runtime: nodejs18.x
+  stage: development
+  region: eu-west-1
+  environment:
+    REGION: eu-west-1
+
+#  iamRoleStatements:
+#    - Effect: "Allow"
+#      Action: "s3:ListBucket"
+#      Resource:
+#        - "arn:aws:s3:::import-service-serverless"
+#    - Effect: "Allow"
+#      Action: "s3:*"
+#      Resource:
+#        - "arn:aws:s3:::import-service-serverless/*"
+#    - Effect: Allow
+#      Action:
+#        - sqs:*
+#      Resource:
+#        - "arn:aws:sqs:eu-west-1:726228754629:catalogItemsQueue"
+
+plugins:
+  - serverless-webpack
+  - serverless-dotenv-plugin
+
+package:
+  individually: true
+
+custom:
+  webpack:
+    includeModules: false
+    webpackConfig: "webpack.config.cjs" # Name of webpack configuration file
+
+functions:
+  basicAuthorizer:
+    handler: handler.basicAuthorizer

--- a/authorization-service/serverless.yml
+++ b/authorization-service/serverless.yml
@@ -9,21 +9,6 @@ provider:
   environment:
     REGION: eu-west-1
 
-#  iamRoleStatements:
-#    - Effect: "Allow"
-#      Action: "s3:ListBucket"
-#      Resource:
-#        - "arn:aws:s3:::import-service-serverless"
-#    - Effect: "Allow"
-#      Action: "s3:*"
-#      Resource:
-#        - "arn:aws:s3:::import-service-serverless/*"
-#    - Effect: Allow
-#      Action:
-#        - sqs:*
-#      Resource:
-#        - "arn:aws:sqs:eu-west-1:726228754629:catalogItemsQueue"
-
 plugins:
   - serverless-webpack
   - serverless-dotenv-plugin

--- a/authorization-service/webpack.config.cjs
+++ b/authorization-service/webpack.config.cjs
@@ -1,0 +1,22 @@
+const path = require("path");
+const slsw = require("serverless-webpack");
+
+module.exports = {
+  entry: slsw.lib.entries,
+  target: "node",
+  mode: slsw.lib.webpack.isLocal ? "development" : "production",
+  stats: "minimal",
+  devtool: "nosources-source-map",
+  performance: {
+    hints: false,
+  },
+  resolve: {
+    extensions: [".js", ".jsx", ".json"],
+  },
+  output: {
+    libraryTarget: "commonjs2",
+    path: path.join(__dirname, ".webpack"),
+    filename: "[name].js",
+    sourceMapFilename: "[file].map",
+  },
+};

--- a/import-service/serverless.yml
+++ b/import-service/serverless.yml
@@ -59,3 +59,18 @@ functions:
             parameters:
               querystrings:
                 name: true
+          authorizer:
+            arn: arn:aws:lambda:eu-west-1:726228754629:function:authorization-service-development-basicAuthorizer
+            type: token
+
+resources:
+  Resources:
+    Unauthorized:
+      Type: AWS::ApiGateway::GatewayResponse
+      Properties:
+        ResponseParameters:
+          "gatewayresponse.header.Access-Control-Allow-Origin": "'*'"
+          "gatewayresponse.header.Access-Control-Allow-Headers": "'*'"
+        ResponseType: "DEFAULT_4XX"
+        RestApiId:
+          Ref: "ApiGatewayRestApi"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.287.0",
+        "@aws-sdk/client-sns": "^3.294.0",
         "@aws-sdk/s3-request-presigner": "^3.287.0",
         "aws-sdk": "^2.1331.0",
         "csv-parser": "^3.0.0",
@@ -254,6 +255,876 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns": {
+      "version": "3.298.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.298.0.tgz",
+      "integrity": "sha512-gNg1DwqnQ3DnxhocE8GjLJR87GjeMA/F2BR1hGp8Vybi+9x+dDXlXJamD27Dy+09ruKu1ih9+68jAyO/VDugDw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.298.0",
+        "@aws-sdk/config-resolver": "3.296.0",
+        "@aws-sdk/credential-provider-node": "3.298.0",
+        "@aws-sdk/fetch-http-handler": "3.296.0",
+        "@aws-sdk/hash-node": "3.296.0",
+        "@aws-sdk/invalid-dependency": "3.296.0",
+        "@aws-sdk/middleware-content-length": "3.296.0",
+        "@aws-sdk/middleware-endpoint": "3.296.0",
+        "@aws-sdk/middleware-host-header": "3.296.0",
+        "@aws-sdk/middleware-logger": "3.296.0",
+        "@aws-sdk/middleware-recursion-detection": "3.296.0",
+        "@aws-sdk/middleware-retry": "3.296.0",
+        "@aws-sdk/middleware-serde": "3.296.0",
+        "@aws-sdk/middleware-signing": "3.296.0",
+        "@aws-sdk/middleware-stack": "3.296.0",
+        "@aws-sdk/middleware-user-agent": "3.296.0",
+        "@aws-sdk/node-config-provider": "3.296.0",
+        "@aws-sdk/node-http-handler": "3.296.0",
+        "@aws-sdk/protocol-http": "3.296.0",
+        "@aws-sdk/smithy-client": "3.296.0",
+        "@aws-sdk/types": "3.296.0",
+        "@aws-sdk/url-parser": "3.296.0",
+        "@aws-sdk/util-base64": "3.295.0",
+        "@aws-sdk/util-body-length-browser": "3.295.0",
+        "@aws-sdk/util-body-length-node": "3.295.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.296.0",
+        "@aws-sdk/util-defaults-mode-node": "3.296.0",
+        "@aws-sdk/util-endpoints": "3.296.0",
+        "@aws-sdk/util-retry": "3.296.0",
+        "@aws-sdk/util-user-agent-browser": "3.296.0",
+        "@aws-sdk/util-user-agent-node": "3.296.0",
+        "@aws-sdk/util-utf8": "3.295.0",
+        "fast-xml-parser": "4.1.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.296.0.tgz",
+      "integrity": "sha512-gNUFBlBw6+sEMfDjPVa83iscpQwXBS4uoiZXnfeQ6s6tnaxqQpJDrBBmNvYqDEXNdaAJX4FhayEwkSvtir/f3A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.296.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/client-sso": {
+      "version": "3.298.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.298.0.tgz",
+      "integrity": "sha512-TNuzxXZj6HbTwjBp8OP3tSAqlwd4HN51fKzcY62haYnPEnI8T5ycB8gj7E0dEvR6mB01JxPucsThAjWSCRM24g==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.296.0",
+        "@aws-sdk/fetch-http-handler": "3.296.0",
+        "@aws-sdk/hash-node": "3.296.0",
+        "@aws-sdk/invalid-dependency": "3.296.0",
+        "@aws-sdk/middleware-content-length": "3.296.0",
+        "@aws-sdk/middleware-endpoint": "3.296.0",
+        "@aws-sdk/middleware-host-header": "3.296.0",
+        "@aws-sdk/middleware-logger": "3.296.0",
+        "@aws-sdk/middleware-recursion-detection": "3.296.0",
+        "@aws-sdk/middleware-retry": "3.296.0",
+        "@aws-sdk/middleware-serde": "3.296.0",
+        "@aws-sdk/middleware-stack": "3.296.0",
+        "@aws-sdk/middleware-user-agent": "3.296.0",
+        "@aws-sdk/node-config-provider": "3.296.0",
+        "@aws-sdk/node-http-handler": "3.296.0",
+        "@aws-sdk/protocol-http": "3.296.0",
+        "@aws-sdk/smithy-client": "3.296.0",
+        "@aws-sdk/types": "3.296.0",
+        "@aws-sdk/url-parser": "3.296.0",
+        "@aws-sdk/util-base64": "3.295.0",
+        "@aws-sdk/util-body-length-browser": "3.295.0",
+        "@aws-sdk/util-body-length-node": "3.295.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.296.0",
+        "@aws-sdk/util-defaults-mode-node": "3.296.0",
+        "@aws-sdk/util-endpoints": "3.296.0",
+        "@aws-sdk/util-retry": "3.296.0",
+        "@aws-sdk/util-user-agent-browser": "3.296.0",
+        "@aws-sdk/util-user-agent-node": "3.296.0",
+        "@aws-sdk/util-utf8": "3.295.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.298.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.298.0.tgz",
+      "integrity": "sha512-i0MMERy6lgaA5btIr2bgEbFbTWccc3/i1gDBMCjHnC42mlChigmwEwzjbGl4Zrhgn915hDIoS9HP2OAym2oTLw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.296.0",
+        "@aws-sdk/fetch-http-handler": "3.296.0",
+        "@aws-sdk/hash-node": "3.296.0",
+        "@aws-sdk/invalid-dependency": "3.296.0",
+        "@aws-sdk/middleware-content-length": "3.296.0",
+        "@aws-sdk/middleware-endpoint": "3.296.0",
+        "@aws-sdk/middleware-host-header": "3.296.0",
+        "@aws-sdk/middleware-logger": "3.296.0",
+        "@aws-sdk/middleware-recursion-detection": "3.296.0",
+        "@aws-sdk/middleware-retry": "3.296.0",
+        "@aws-sdk/middleware-serde": "3.296.0",
+        "@aws-sdk/middleware-stack": "3.296.0",
+        "@aws-sdk/middleware-user-agent": "3.296.0",
+        "@aws-sdk/node-config-provider": "3.296.0",
+        "@aws-sdk/node-http-handler": "3.296.0",
+        "@aws-sdk/protocol-http": "3.296.0",
+        "@aws-sdk/smithy-client": "3.296.0",
+        "@aws-sdk/types": "3.296.0",
+        "@aws-sdk/url-parser": "3.296.0",
+        "@aws-sdk/util-base64": "3.295.0",
+        "@aws-sdk/util-body-length-browser": "3.295.0",
+        "@aws-sdk/util-body-length-node": "3.295.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.296.0",
+        "@aws-sdk/util-defaults-mode-node": "3.296.0",
+        "@aws-sdk/util-endpoints": "3.296.0",
+        "@aws-sdk/util-retry": "3.296.0",
+        "@aws-sdk/util-user-agent-browser": "3.296.0",
+        "@aws-sdk/util-user-agent-node": "3.296.0",
+        "@aws-sdk/util-utf8": "3.295.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/client-sts": {
+      "version": "3.298.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.298.0.tgz",
+      "integrity": "sha512-6+m13g5EN2uYfY6sKcvrlK+uNuO3vMdD+VY4PEjs2I4Prt1BfTgBQ0QZpFnc4SPk8pfhBAx+wSJgyqS9xri9cw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.296.0",
+        "@aws-sdk/credential-provider-node": "3.298.0",
+        "@aws-sdk/fetch-http-handler": "3.296.0",
+        "@aws-sdk/hash-node": "3.296.0",
+        "@aws-sdk/invalid-dependency": "3.296.0",
+        "@aws-sdk/middleware-content-length": "3.296.0",
+        "@aws-sdk/middleware-endpoint": "3.296.0",
+        "@aws-sdk/middleware-host-header": "3.296.0",
+        "@aws-sdk/middleware-logger": "3.296.0",
+        "@aws-sdk/middleware-recursion-detection": "3.296.0",
+        "@aws-sdk/middleware-retry": "3.296.0",
+        "@aws-sdk/middleware-sdk-sts": "3.296.0",
+        "@aws-sdk/middleware-serde": "3.296.0",
+        "@aws-sdk/middleware-signing": "3.296.0",
+        "@aws-sdk/middleware-stack": "3.296.0",
+        "@aws-sdk/middleware-user-agent": "3.296.0",
+        "@aws-sdk/node-config-provider": "3.296.0",
+        "@aws-sdk/node-http-handler": "3.296.0",
+        "@aws-sdk/protocol-http": "3.296.0",
+        "@aws-sdk/smithy-client": "3.296.0",
+        "@aws-sdk/types": "3.296.0",
+        "@aws-sdk/url-parser": "3.296.0",
+        "@aws-sdk/util-base64": "3.295.0",
+        "@aws-sdk/util-body-length-browser": "3.295.0",
+        "@aws-sdk/util-body-length-node": "3.295.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.296.0",
+        "@aws-sdk/util-defaults-mode-node": "3.296.0",
+        "@aws-sdk/util-endpoints": "3.296.0",
+        "@aws-sdk/util-retry": "3.296.0",
+        "@aws-sdk/util-user-agent-browser": "3.296.0",
+        "@aws-sdk/util-user-agent-node": "3.296.0",
+        "@aws-sdk/util-utf8": "3.295.0",
+        "fast-xml-parser": "4.1.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.296.0.tgz",
+      "integrity": "sha512-Ecdp7fmIitHo49NRCyIEHb9xlI43J7qkvhcwaKGGqN5jvoh0YhR2vNr195wWG8Ip/9PwsD4QV4g/XT5EY7XkMA==",
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.296.0",
+        "@aws-sdk/types": "3.296.0",
+        "@aws-sdk/util-config-provider": "3.295.0",
+        "@aws-sdk/util-middleware": "3.296.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.296.0.tgz",
+      "integrity": "sha512-eDWSU3p04gytkkVXnYn05YzrP5SEaj/DQiafd4y+iBl8IFfF3zM6982rs6qFhvpwrHeSbLqHNfKR1HDWVwfG5g==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.296.0",
+        "@aws-sdk/types": "3.296.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.296.0.tgz",
+      "integrity": "sha512-DXqksHyT/GVVYbPGknMARKi6Rk6cqCHJUAejePIx5cz1SCKlDrV704hykafHIjaDoy/Zeoj1wzjfwy83sJfDCg==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.296.0",
+        "@aws-sdk/property-provider": "3.296.0",
+        "@aws-sdk/types": "3.296.0",
+        "@aws-sdk/url-parser": "3.296.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.298.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.298.0.tgz",
+      "integrity": "sha512-+2pP5DqTuuPIKiM5BeGhBLjLvmnY+hl1FZU+xC5qhhmBj4QqTmcT2O1QaRzbM6EB/DNmG1XNgMNRolOakHGpNg==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.296.0",
+        "@aws-sdk/credential-provider-imds": "3.296.0",
+        "@aws-sdk/credential-provider-process": "3.296.0",
+        "@aws-sdk/credential-provider-sso": "3.298.0",
+        "@aws-sdk/credential-provider-web-identity": "3.296.0",
+        "@aws-sdk/property-provider": "3.296.0",
+        "@aws-sdk/shared-ini-file-loader": "3.296.0",
+        "@aws-sdk/types": "3.296.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.298.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.298.0.tgz",
+      "integrity": "sha512-M10EV8wInzfP6A9xoD3SObbJSeUdWo1C27kifpmym6EzG4Q0Pegkf37vwtSd4u/5aGT0CIfKA3ti3bYSst9+4Q==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.296.0",
+        "@aws-sdk/credential-provider-imds": "3.296.0",
+        "@aws-sdk/credential-provider-ini": "3.298.0",
+        "@aws-sdk/credential-provider-process": "3.296.0",
+        "@aws-sdk/credential-provider-sso": "3.298.0",
+        "@aws-sdk/credential-provider-web-identity": "3.296.0",
+        "@aws-sdk/property-provider": "3.296.0",
+        "@aws-sdk/shared-ini-file-loader": "3.296.0",
+        "@aws-sdk/types": "3.296.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.296.0.tgz",
+      "integrity": "sha512-AY7sTX2dGi8ripuCpcJLYHOZB2wJ6NnseyK/kK5TfJn/pgboKwuGtz0hkJCVprNWomKa6IpHksm7vLQ4O2E+UA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.296.0",
+        "@aws-sdk/shared-ini-file-loader": "3.296.0",
+        "@aws-sdk/types": "3.296.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.298.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.298.0.tgz",
+      "integrity": "sha512-NFjuVj9Vndk0AcnYqPx1eWIMdGY0XB1hI7CJWW4Rlu+YK04qIyxtZ2Hhva6GxPwUPXCzQfxuYikU2mKFkYSlvw==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.298.0",
+        "@aws-sdk/property-provider": "3.296.0",
+        "@aws-sdk/shared-ini-file-loader": "3.296.0",
+        "@aws-sdk/token-providers": "3.298.0",
+        "@aws-sdk/types": "3.296.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.296.0.tgz",
+      "integrity": "sha512-Rl6Ohoekxe+pccA55XXQDW5wApbg3rGWr6FkmPRcg7Ld6Vfe+HL8OtfsFf83/0eoFerevbif+00BdknXWT05LA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.296.0",
+        "@aws-sdk/types": "3.296.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.296.0.tgz",
+      "integrity": "sha512-wHuKQ+PGKQkYGVuIGscbcbbASl8yIVOSC+QTrZQ4PNsMDvQd9ey2npsmxZk1Z2ULaxY+qYtZCmByyGc8k51TtQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.296.0",
+        "@aws-sdk/querystring-builder": "3.296.0",
+        "@aws-sdk/types": "3.296.0",
+        "@aws-sdk/util-base64": "3.295.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/hash-node": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.296.0.tgz",
+      "integrity": "sha512-01Sgxm0NE3rtEznLY8vx1bfNsIeM5Sk5SjY9RXqnvCf9EyaKH9x5FMS/DX/SgDdIYi3aXbTwiwScNVCNBzOIQA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.296.0",
+        "@aws-sdk/util-buffer-from": "3.295.0",
+        "@aws-sdk/util-utf8": "3.295.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.296.0.tgz",
+      "integrity": "sha512-dmy4fUds0woHGjxwziaSYCLtb/SOfoEeQjW0GFvHj+YGFyY5hJzna4C759Tt8X5obh1evUXlQcH+FL7TS+7tRQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.296.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.295.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.295.0.tgz",
+      "integrity": "sha512-SCIt10cr5dud7hvwveU4wkLjvkGssJ3GrcbHCds2NwI+JHmpcaaNYLAqi305JAuT29T36U5ssTFDSmrrEOcfag==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.296.0.tgz",
+      "integrity": "sha512-e7lJm3kkC2pWZdIw23gpMUk1GrpRTBRqhdFfVwyduXw6Wo4nBYv8Z5MOYy3/SlpjE1BDCaPBoZ3O19cO3arHxg==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.296.0",
+        "@aws-sdk/types": "3.296.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.296.0.tgz",
+      "integrity": "sha512-t8gc7FHr6KkFD35eSzv3VEYl2vNqzAHbux5Bn0su6TJbaTxXiQKcf2jZDTAh7LzUyrB1LH39mNN+at7r3Qm/3g==",
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.296.0",
+        "@aws-sdk/protocol-http": "3.296.0",
+        "@aws-sdk/signature-v4": "3.296.0",
+        "@aws-sdk/types": "3.296.0",
+        "@aws-sdk/url-parser": "3.296.0",
+        "@aws-sdk/util-config-provider": "3.295.0",
+        "@aws-sdk/util-middleware": "3.296.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.296.0.tgz",
+      "integrity": "sha512-V47dFtfkX5lXWv9GDp71gZVCRws4fEdQ9QF9BQ/2UMSNrYjQLg6mFe7NibH+IJoNOid2FIwWIl94Eos636VGYQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.296.0",
+        "@aws-sdk/types": "3.296.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.296.0.tgz",
+      "integrity": "sha512-LzfEEFyBR9LXdWwLdtBrmi1vLdzgdJNntEgzqktVF8LwaCyY+9xIE6TGu/2V+9fJHAwECxjOC1eQbNQdAZ0Tmw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.296.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.296.0.tgz",
+      "integrity": "sha512-UG7TLDPz9ImQG0uVklHTxE9Us7rTImwN+6el6qZCpoTBuGeXgOkfb0/p8izJyFgY/hMUR4cZqs7IdCDUkxQF3w==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.296.0",
+        "@aws-sdk/types": "3.296.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.296.0.tgz",
+      "integrity": "sha512-Tz3gDZm5viQg7BG5bF9Cg0qbm4+Ur3a7wcGkj1XHQdzGDYR76gxvU0bfnSNUmWRz3kaVNyISyXSOUygG0cbhbw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.296.0",
+        "@aws-sdk/service-error-classification": "3.296.0",
+        "@aws-sdk/types": "3.296.0",
+        "@aws-sdk/util-middleware": "3.296.0",
+        "@aws-sdk/util-retry": "3.296.0",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.296.0.tgz",
+      "integrity": "sha512-0EnHtiRzcRcXaF6zEgcRGUtVgX0RqczwlGXjtryHcxiqU/+adqbRuckC7bdMF4Zva6GVPS25XppvGF4M+UzAEw==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.296.0",
+        "@aws-sdk/property-provider": "3.296.0",
+        "@aws-sdk/protocol-http": "3.296.0",
+        "@aws-sdk/signature-v4": "3.296.0",
+        "@aws-sdk/types": "3.296.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.296.0.tgz",
+      "integrity": "sha512-xk2PpWAAX758oUTGkGBAncpOr7ddIXisjD2Y2r9DDXuE4JMho2x6zcrVSiYsGIQ6MHZ9XNJKBVDiK9PA4iQWGQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.296.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.296.0.tgz",
+      "integrity": "sha512-wyiG+WPDvugGTIPpKchGOdvvpcMZEN2IfP6iK//QAqGXsC6rDm5+SNZ3+elvduZjPUdVA06W0CcFYBAkVz8D7Q==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.296.0",
+        "@aws-sdk/protocol-http": "3.296.0",
+        "@aws-sdk/signature-v4": "3.296.0",
+        "@aws-sdk/types": "3.296.0",
+        "@aws-sdk/util-middleware": "3.296.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.296.0.tgz",
+      "integrity": "sha512-Rgo7/mdk9tt4qa9+pzG3AoGNhuj7NmnF5H+3DoPm75h58BYP8hKbKobdPGgI2rZLPtO3PGgmyw/4K4tQJPIZ8g==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.296.0.tgz",
+      "integrity": "sha512-L7jacxSt6gxX1gD3tQtfwHqBDk5rT2wWD3rxBa6rs7f81b9ObgY/sPT2IgRT7JNCVzvKLYFxJaTklDj65mY1SQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.296.0",
+        "@aws-sdk/types": "3.296.0",
+        "@aws-sdk/util-endpoints": "3.296.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.296.0.tgz",
+      "integrity": "sha512-S/tYcuw9ACOWRmRe5oUkmutQ+TApjVs0yDl504DKs74f3p4kRgI/MGWkBiR3mcfThHaxu81z0gkRL2qfW2SDwg==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.296.0",
+        "@aws-sdk/shared-ini-file-loader": "3.296.0",
+        "@aws-sdk/types": "3.296.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.296.0.tgz",
+      "integrity": "sha512-D15jjPqYSNhEq58BwkmIpD3VwqG4bL5acAaNu5wWAI4S4236JlG+nmpi3gEeE25z1KCwtBl7G30fVRgXYJ2CWA==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.296.0",
+        "@aws-sdk/protocol-http": "3.296.0",
+        "@aws-sdk/querystring-builder": "3.296.0",
+        "@aws-sdk/types": "3.296.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/property-provider": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.296.0.tgz",
+      "integrity": "sha512-kjczxE9Od5LoAKQOmxVWISJ9oPG3aCsB+2+NdI+k9EJFDXUUdMcVV3Skei5uHGgKLMsI6CZy8ezZx6YxOSLSew==",
+      "dependencies": {
+        "@aws-sdk/types": "3.296.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.296.0.tgz",
+      "integrity": "sha512-0U1Z/+tpwdRiSToWo1bpdkbTzjbLugTnd02ATjvK4B7zi363SUGlKfoWgV+v7FU/22CIUI1ZIe7XzXvq5rJfjA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.296.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.296.0.tgz",
+      "integrity": "sha512-+ZrZdTRaVI1R1xKQNrTwuiRoPateUaJ/DNw/myJpTPt+ZRg0H7LKBGaJYwL4pl5l/z1UM/E1fOttSfSW7GHxfw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.296.0",
+        "@aws-sdk/util-uri-escape": "3.295.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.296.0.tgz",
+      "integrity": "sha512-nLNZKVQfK42euv7101cE5qfg17YCtGcfccx3B5XSAzvyTROR46kwYqbEvYSsWisbZoRhbQc905gB/5E0U5HDIw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.296.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.296.0.tgz",
+      "integrity": "sha512-YIsWSQ38e1+FqXz3CMrkKS0JD8OLlHf6I72PJhbfegePpQQFqi9R8OREjP5V7UR9Z972yruv4i96ROH6SCtmoA==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.296.0.tgz",
+      "integrity": "sha512-S31VfdiruN2trayoeB7HifsEB+WXhtfECosj90K903rzfyX+Eo+uUoK9O07UotxJ2gB3MBQ7R8pNnZio3Lb66w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.296.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.296.0.tgz",
+      "integrity": "sha512-NQyJ/FClty4VmF1WoV4rOkbN0Unn0zevzy8iJrYhqxE3Sc7lySM4Btnsd4Iqelm2dR6l+jNRApGgD8NvoGjGig==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.295.0",
+        "@aws-sdk/types": "3.296.0",
+        "@aws-sdk/util-hex-encoding": "3.295.0",
+        "@aws-sdk/util-middleware": "3.296.0",
+        "@aws-sdk/util-uri-escape": "3.295.0",
+        "@aws-sdk/util-utf8": "3.295.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.296.0.tgz",
+      "integrity": "sha512-HEpsLNozGe9XOWouq5A1TFw5KhFodi8tZqYVNEbSpLoRR+EQKf6OCRvKIRkOn7FnnaOasOR1n7S0D51UG6/irw==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.296.0",
+        "@aws-sdk/types": "3.296.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/token-providers": {
+      "version": "3.298.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.298.0.tgz",
+      "integrity": "sha512-hnUDpK2SPLPJj3wAjWLvKhqditGiDr+V7HLtmqoSOFcXpLuIXE2gjmdADrOVB40t38r/oPQeeQIhUjwgm8HNGA==",
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.298.0",
+        "@aws-sdk/property-provider": "3.296.0",
+        "@aws-sdk/shared-ini-file-loader": "3.296.0",
+        "@aws-sdk/types": "3.296.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/types": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.296.0.tgz",
+      "integrity": "sha512-s0wIac64rrMEo2ioUxP9IarGiiCGmelCspNcoNTPSjGl25QqjhyfQqTeGgS58qJ4fHoQb07qra39930xp1IzJg==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/url-parser": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.296.0.tgz",
+      "integrity": "sha512-nBgeGF+ziuDSLz+y8UAl6zL2tXxDwh3wqeXFe9ZcR4YW71BWuh+vEqEsaEMutOrfnJacCrYKTs9TkIOW41cEGg==",
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.296.0",
+        "@aws-sdk/types": "3.296.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-base64": {
+      "version": "3.295.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.295.0.tgz",
+      "integrity": "sha512-z1r40BsBiOTALnzASvLb4qutGwPpL+jH2UKTCV5WJLXZFMzRnpZaRfeZGE8lMJ/i0+jv9H9G1FmVzE8UgB4rhw==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.295.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.295.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.295.0.tgz",
+      "integrity": "sha512-NbG4/RSHV1VueStPRclSo5zRjNUmcDlNAs29sniZF+YaN0+Ad7hEdu/YgJw39shBfUaurz2Wv0pufU3cxE5Tng==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.295.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.295.0.tgz",
+      "integrity": "sha512-dvGf8VBmrT66lM0n6P/h7wnlHS4Atafyivyl8f4TUCMvRdpqryvvrtnX6yYcq3T7VKQmas/2SOlgDvcrhGXaiw==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.295.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.295.0.tgz",
+      "integrity": "sha512-5ezVEITQnrQKn+CU9qfZHgRp2nrrbX0Clmlm9aiNjAEQEPHY33tWl0t6n8h8yU+IpGiNRMWBVC4aSJaE5NA1mA==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.295.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.295.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.295.0.tgz",
+      "integrity": "sha512-/5Dl1aV2yI8YQjqwmg4RTnl/E9NmNsx7HIwBZt+dTcOrM0LMUwczQBFFcLyqCj/qv5y+VsvLoAAA/OiBT7hb3w==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.296.0.tgz",
+      "integrity": "sha512-R+nzc0PuTMaOG3LV4FoS5W7oMAqqr8G1IyI+A4Q5iem6YDMF157qV5h6wpIt3A8n9YfjyssLsAT/WPfyv/M79w==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.296.0",
+        "@aws-sdk/types": "3.296.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.296.0.tgz",
+      "integrity": "sha512-zsIYynqjBE2xlzpJsT3lb5gy06undSgYq9ziId7QaHFagqtrecHI2ZMcu2tBFcONpu9NPj3nqJB+kJUAnBc8sQ==",
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.296.0",
+        "@aws-sdk/credential-provider-imds": "3.296.0",
+        "@aws-sdk/node-config-provider": "3.296.0",
+        "@aws-sdk/property-provider": "3.296.0",
+        "@aws-sdk/types": "3.296.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.296.0.tgz",
+      "integrity": "sha512-YraGGLJepXM6HCTaqEGTFf8RFRBdJ0C6uG5k0kVhiXmYxBkeupn8J07CVp9jfWqcPYWElAnMGVEZKU1OjRo4HQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.296.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.295.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.295.0.tgz",
+      "integrity": "sha512-XJcoVo41kHzhe28PBm/rqt5mdCp8R6abwiW9ug1dA6FOoPUO8kBUxDv6xaOmA2hfRvd2ocFfBXaUCBqUowkGcQ==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-middleware": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.296.0.tgz",
+      "integrity": "sha512-MNWU+doVuX+mIehEManP6OP+f08T33qQpHoBqKIeKpn3TjZjMHG7ujACTkJiEOHUrnwTov7h0Sm+3OZwk3kh9w==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-retry": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.296.0.tgz",
+      "integrity": "sha512-0mh7SqOMjuJ4vE423SzA/AfCLM68jykbfpEBkTmfqkpjkeQSW+UXHAUdXsMmfzIneiq7go5Z548F868C3cZnwQ==",
+      "dependencies": {
+        "@aws-sdk/service-error-classification": "3.296.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.295.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.295.0.tgz",
+      "integrity": "sha512-1H5DcyIoXF8XcPBWf7wzHt0l+TW2EoR8Oq4gsVrPTQkHMTVclC2Yn8EF3gc4arwVBzwLulI9LMBE2L8fexGfTQ==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.296.0.tgz",
+      "integrity": "sha512-MGGG+09VkF0N+8KEht8NNE6Q7bqmddgqLkUbvzSky0y18UPEZyq9LTC4JZtzDDOzf/swgbq2IQ/5wtB81iouog==",
+      "dependencies": {
+        "@aws-sdk/types": "3.296.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.296.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.296.0.tgz",
+      "integrity": "sha512-AMWac8aIBnaa9nxAEpZ752j29a/UQTViRfR5gnCX38ECBKGfOQMpgYnee5HdlMr4GHJj0WkOzQxBtInW4pV58g==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.296.0",
+        "@aws-sdk/types": "3.296.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-utf8": {
+      "version": "3.295.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.295.0.tgz",
+      "integrity": "sha512-ITN8v3F63ZkA4sdmCtSbS/mhav4F0MEAiXDAUXtMJLNqVtaVcyQST4i9vNmPpIVthAPAtP0QjyF2tq/Di8bxtQ==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.295.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-sdk/client-sso": {
@@ -13501,6 +14372,714 @@
         "@aws-sdk/xml-builder": "3.201.0",
         "fast-xml-parser": "4.1.2",
         "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-sns": {
+      "version": "3.298.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.298.0.tgz",
+      "integrity": "sha512-gNg1DwqnQ3DnxhocE8GjLJR87GjeMA/F2BR1hGp8Vybi+9x+dDXlXJamD27Dy+09ruKu1ih9+68jAyO/VDugDw==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.298.0",
+        "@aws-sdk/config-resolver": "3.296.0",
+        "@aws-sdk/credential-provider-node": "3.298.0",
+        "@aws-sdk/fetch-http-handler": "3.296.0",
+        "@aws-sdk/hash-node": "3.296.0",
+        "@aws-sdk/invalid-dependency": "3.296.0",
+        "@aws-sdk/middleware-content-length": "3.296.0",
+        "@aws-sdk/middleware-endpoint": "3.296.0",
+        "@aws-sdk/middleware-host-header": "3.296.0",
+        "@aws-sdk/middleware-logger": "3.296.0",
+        "@aws-sdk/middleware-recursion-detection": "3.296.0",
+        "@aws-sdk/middleware-retry": "3.296.0",
+        "@aws-sdk/middleware-serde": "3.296.0",
+        "@aws-sdk/middleware-signing": "3.296.0",
+        "@aws-sdk/middleware-stack": "3.296.0",
+        "@aws-sdk/middleware-user-agent": "3.296.0",
+        "@aws-sdk/node-config-provider": "3.296.0",
+        "@aws-sdk/node-http-handler": "3.296.0",
+        "@aws-sdk/protocol-http": "3.296.0",
+        "@aws-sdk/smithy-client": "3.296.0",
+        "@aws-sdk/types": "3.296.0",
+        "@aws-sdk/url-parser": "3.296.0",
+        "@aws-sdk/util-base64": "3.295.0",
+        "@aws-sdk/util-body-length-browser": "3.295.0",
+        "@aws-sdk/util-body-length-node": "3.295.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.296.0",
+        "@aws-sdk/util-defaults-mode-node": "3.296.0",
+        "@aws-sdk/util-endpoints": "3.296.0",
+        "@aws-sdk/util-retry": "3.296.0",
+        "@aws-sdk/util-user-agent-browser": "3.296.0",
+        "@aws-sdk/util-user-agent-node": "3.296.0",
+        "@aws-sdk/util-utf8": "3.295.0",
+        "fast-xml-parser": "4.1.2",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/abort-controller": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.296.0.tgz",
+          "integrity": "sha512-gNUFBlBw6+sEMfDjPVa83iscpQwXBS4uoiZXnfeQ6s6tnaxqQpJDrBBmNvYqDEXNdaAJX4FhayEwkSvtir/f3A==",
+          "requires": {
+            "@aws-sdk/types": "3.296.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/client-sso": {
+          "version": "3.298.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.298.0.tgz",
+          "integrity": "sha512-TNuzxXZj6HbTwjBp8OP3tSAqlwd4HN51fKzcY62haYnPEnI8T5ycB8gj7E0dEvR6mB01JxPucsThAjWSCRM24g==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/config-resolver": "3.296.0",
+            "@aws-sdk/fetch-http-handler": "3.296.0",
+            "@aws-sdk/hash-node": "3.296.0",
+            "@aws-sdk/invalid-dependency": "3.296.0",
+            "@aws-sdk/middleware-content-length": "3.296.0",
+            "@aws-sdk/middleware-endpoint": "3.296.0",
+            "@aws-sdk/middleware-host-header": "3.296.0",
+            "@aws-sdk/middleware-logger": "3.296.0",
+            "@aws-sdk/middleware-recursion-detection": "3.296.0",
+            "@aws-sdk/middleware-retry": "3.296.0",
+            "@aws-sdk/middleware-serde": "3.296.0",
+            "@aws-sdk/middleware-stack": "3.296.0",
+            "@aws-sdk/middleware-user-agent": "3.296.0",
+            "@aws-sdk/node-config-provider": "3.296.0",
+            "@aws-sdk/node-http-handler": "3.296.0",
+            "@aws-sdk/protocol-http": "3.296.0",
+            "@aws-sdk/smithy-client": "3.296.0",
+            "@aws-sdk/types": "3.296.0",
+            "@aws-sdk/url-parser": "3.296.0",
+            "@aws-sdk/util-base64": "3.295.0",
+            "@aws-sdk/util-body-length-browser": "3.295.0",
+            "@aws-sdk/util-body-length-node": "3.295.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.296.0",
+            "@aws-sdk/util-defaults-mode-node": "3.296.0",
+            "@aws-sdk/util-endpoints": "3.296.0",
+            "@aws-sdk/util-retry": "3.296.0",
+            "@aws-sdk/util-user-agent-browser": "3.296.0",
+            "@aws-sdk/util-user-agent-node": "3.296.0",
+            "@aws-sdk/util-utf8": "3.295.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/client-sso-oidc": {
+          "version": "3.298.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.298.0.tgz",
+          "integrity": "sha512-i0MMERy6lgaA5btIr2bgEbFbTWccc3/i1gDBMCjHnC42mlChigmwEwzjbGl4Zrhgn915hDIoS9HP2OAym2oTLw==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/config-resolver": "3.296.0",
+            "@aws-sdk/fetch-http-handler": "3.296.0",
+            "@aws-sdk/hash-node": "3.296.0",
+            "@aws-sdk/invalid-dependency": "3.296.0",
+            "@aws-sdk/middleware-content-length": "3.296.0",
+            "@aws-sdk/middleware-endpoint": "3.296.0",
+            "@aws-sdk/middleware-host-header": "3.296.0",
+            "@aws-sdk/middleware-logger": "3.296.0",
+            "@aws-sdk/middleware-recursion-detection": "3.296.0",
+            "@aws-sdk/middleware-retry": "3.296.0",
+            "@aws-sdk/middleware-serde": "3.296.0",
+            "@aws-sdk/middleware-stack": "3.296.0",
+            "@aws-sdk/middleware-user-agent": "3.296.0",
+            "@aws-sdk/node-config-provider": "3.296.0",
+            "@aws-sdk/node-http-handler": "3.296.0",
+            "@aws-sdk/protocol-http": "3.296.0",
+            "@aws-sdk/smithy-client": "3.296.0",
+            "@aws-sdk/types": "3.296.0",
+            "@aws-sdk/url-parser": "3.296.0",
+            "@aws-sdk/util-base64": "3.295.0",
+            "@aws-sdk/util-body-length-browser": "3.295.0",
+            "@aws-sdk/util-body-length-node": "3.295.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.296.0",
+            "@aws-sdk/util-defaults-mode-node": "3.296.0",
+            "@aws-sdk/util-endpoints": "3.296.0",
+            "@aws-sdk/util-retry": "3.296.0",
+            "@aws-sdk/util-user-agent-browser": "3.296.0",
+            "@aws-sdk/util-user-agent-node": "3.296.0",
+            "@aws-sdk/util-utf8": "3.295.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.298.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.298.0.tgz",
+          "integrity": "sha512-6+m13g5EN2uYfY6sKcvrlK+uNuO3vMdD+VY4PEjs2I4Prt1BfTgBQ0QZpFnc4SPk8pfhBAx+wSJgyqS9xri9cw==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/config-resolver": "3.296.0",
+            "@aws-sdk/credential-provider-node": "3.298.0",
+            "@aws-sdk/fetch-http-handler": "3.296.0",
+            "@aws-sdk/hash-node": "3.296.0",
+            "@aws-sdk/invalid-dependency": "3.296.0",
+            "@aws-sdk/middleware-content-length": "3.296.0",
+            "@aws-sdk/middleware-endpoint": "3.296.0",
+            "@aws-sdk/middleware-host-header": "3.296.0",
+            "@aws-sdk/middleware-logger": "3.296.0",
+            "@aws-sdk/middleware-recursion-detection": "3.296.0",
+            "@aws-sdk/middleware-retry": "3.296.0",
+            "@aws-sdk/middleware-sdk-sts": "3.296.0",
+            "@aws-sdk/middleware-serde": "3.296.0",
+            "@aws-sdk/middleware-signing": "3.296.0",
+            "@aws-sdk/middleware-stack": "3.296.0",
+            "@aws-sdk/middleware-user-agent": "3.296.0",
+            "@aws-sdk/node-config-provider": "3.296.0",
+            "@aws-sdk/node-http-handler": "3.296.0",
+            "@aws-sdk/protocol-http": "3.296.0",
+            "@aws-sdk/smithy-client": "3.296.0",
+            "@aws-sdk/types": "3.296.0",
+            "@aws-sdk/url-parser": "3.296.0",
+            "@aws-sdk/util-base64": "3.295.0",
+            "@aws-sdk/util-body-length-browser": "3.295.0",
+            "@aws-sdk/util-body-length-node": "3.295.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.296.0",
+            "@aws-sdk/util-defaults-mode-node": "3.296.0",
+            "@aws-sdk/util-endpoints": "3.296.0",
+            "@aws-sdk/util-retry": "3.296.0",
+            "@aws-sdk/util-user-agent-browser": "3.296.0",
+            "@aws-sdk/util-user-agent-node": "3.296.0",
+            "@aws-sdk/util-utf8": "3.295.0",
+            "fast-xml-parser": "4.1.2",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.296.0.tgz",
+          "integrity": "sha512-Ecdp7fmIitHo49NRCyIEHb9xlI43J7qkvhcwaKGGqN5jvoh0YhR2vNr195wWG8Ip/9PwsD4QV4g/XT5EY7XkMA==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.296.0",
+            "@aws-sdk/types": "3.296.0",
+            "@aws-sdk/util-config-provider": "3.295.0",
+            "@aws-sdk/util-middleware": "3.296.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.296.0.tgz",
+          "integrity": "sha512-eDWSU3p04gytkkVXnYn05YzrP5SEaj/DQiafd4y+iBl8IFfF3zM6982rs6qFhvpwrHeSbLqHNfKR1HDWVwfG5g==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.296.0",
+            "@aws-sdk/types": "3.296.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.296.0.tgz",
+          "integrity": "sha512-DXqksHyT/GVVYbPGknMARKi6Rk6cqCHJUAejePIx5cz1SCKlDrV704hykafHIjaDoy/Zeoj1wzjfwy83sJfDCg==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.296.0",
+            "@aws-sdk/property-provider": "3.296.0",
+            "@aws-sdk/types": "3.296.0",
+            "@aws-sdk/url-parser": "3.296.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.298.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.298.0.tgz",
+          "integrity": "sha512-+2pP5DqTuuPIKiM5BeGhBLjLvmnY+hl1FZU+xC5qhhmBj4QqTmcT2O1QaRzbM6EB/DNmG1XNgMNRolOakHGpNg==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.296.0",
+            "@aws-sdk/credential-provider-imds": "3.296.0",
+            "@aws-sdk/credential-provider-process": "3.296.0",
+            "@aws-sdk/credential-provider-sso": "3.298.0",
+            "@aws-sdk/credential-provider-web-identity": "3.296.0",
+            "@aws-sdk/property-provider": "3.296.0",
+            "@aws-sdk/shared-ini-file-loader": "3.296.0",
+            "@aws-sdk/types": "3.296.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.298.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.298.0.tgz",
+          "integrity": "sha512-M10EV8wInzfP6A9xoD3SObbJSeUdWo1C27kifpmym6EzG4Q0Pegkf37vwtSd4u/5aGT0CIfKA3ti3bYSst9+4Q==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.296.0",
+            "@aws-sdk/credential-provider-imds": "3.296.0",
+            "@aws-sdk/credential-provider-ini": "3.298.0",
+            "@aws-sdk/credential-provider-process": "3.296.0",
+            "@aws-sdk/credential-provider-sso": "3.298.0",
+            "@aws-sdk/credential-provider-web-identity": "3.296.0",
+            "@aws-sdk/property-provider": "3.296.0",
+            "@aws-sdk/shared-ini-file-loader": "3.296.0",
+            "@aws-sdk/types": "3.296.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.296.0.tgz",
+          "integrity": "sha512-AY7sTX2dGi8ripuCpcJLYHOZB2wJ6NnseyK/kK5TfJn/pgboKwuGtz0hkJCVprNWomKa6IpHksm7vLQ4O2E+UA==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.296.0",
+            "@aws-sdk/shared-ini-file-loader": "3.296.0",
+            "@aws-sdk/types": "3.296.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.298.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.298.0.tgz",
+          "integrity": "sha512-NFjuVj9Vndk0AcnYqPx1eWIMdGY0XB1hI7CJWW4Rlu+YK04qIyxtZ2Hhva6GxPwUPXCzQfxuYikU2mKFkYSlvw==",
+          "requires": {
+            "@aws-sdk/client-sso": "3.298.0",
+            "@aws-sdk/property-provider": "3.296.0",
+            "@aws-sdk/shared-ini-file-loader": "3.296.0",
+            "@aws-sdk/token-providers": "3.298.0",
+            "@aws-sdk/types": "3.296.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.296.0.tgz",
+          "integrity": "sha512-Rl6Ohoekxe+pccA55XXQDW5wApbg3rGWr6FkmPRcg7Ld6Vfe+HL8OtfsFf83/0eoFerevbif+00BdknXWT05LA==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.296.0",
+            "@aws-sdk/types": "3.296.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.296.0.tgz",
+          "integrity": "sha512-wHuKQ+PGKQkYGVuIGscbcbbASl8yIVOSC+QTrZQ4PNsMDvQd9ey2npsmxZk1Z2ULaxY+qYtZCmByyGc8k51TtQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.296.0",
+            "@aws-sdk/querystring-builder": "3.296.0",
+            "@aws-sdk/types": "3.296.0",
+            "@aws-sdk/util-base64": "3.295.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.296.0.tgz",
+          "integrity": "sha512-01Sgxm0NE3rtEznLY8vx1bfNsIeM5Sk5SjY9RXqnvCf9EyaKH9x5FMS/DX/SgDdIYi3aXbTwiwScNVCNBzOIQA==",
+          "requires": {
+            "@aws-sdk/types": "3.296.0",
+            "@aws-sdk/util-buffer-from": "3.295.0",
+            "@aws-sdk/util-utf8": "3.295.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.296.0.tgz",
+          "integrity": "sha512-dmy4fUds0woHGjxwziaSYCLtb/SOfoEeQjW0GFvHj+YGFyY5hJzna4C759Tt8X5obh1evUXlQcH+FL7TS+7tRQ==",
+          "requires": {
+            "@aws-sdk/types": "3.296.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.295.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.295.0.tgz",
+          "integrity": "sha512-SCIt10cr5dud7hvwveU4wkLjvkGssJ3GrcbHCds2NwI+JHmpcaaNYLAqi305JAuT29T36U5ssTFDSmrrEOcfag==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.296.0.tgz",
+          "integrity": "sha512-e7lJm3kkC2pWZdIw23gpMUk1GrpRTBRqhdFfVwyduXw6Wo4nBYv8Z5MOYy3/SlpjE1BDCaPBoZ3O19cO3arHxg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.296.0",
+            "@aws-sdk/types": "3.296.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-endpoint": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.296.0.tgz",
+          "integrity": "sha512-t8gc7FHr6KkFD35eSzv3VEYl2vNqzAHbux5Bn0su6TJbaTxXiQKcf2jZDTAh7LzUyrB1LH39mNN+at7r3Qm/3g==",
+          "requires": {
+            "@aws-sdk/middleware-serde": "3.296.0",
+            "@aws-sdk/protocol-http": "3.296.0",
+            "@aws-sdk/signature-v4": "3.296.0",
+            "@aws-sdk/types": "3.296.0",
+            "@aws-sdk/url-parser": "3.296.0",
+            "@aws-sdk/util-config-provider": "3.295.0",
+            "@aws-sdk/util-middleware": "3.296.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.296.0.tgz",
+          "integrity": "sha512-V47dFtfkX5lXWv9GDp71gZVCRws4fEdQ9QF9BQ/2UMSNrYjQLg6mFe7NibH+IJoNOid2FIwWIl94Eos636VGYQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.296.0",
+            "@aws-sdk/types": "3.296.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.296.0.tgz",
+          "integrity": "sha512-LzfEEFyBR9LXdWwLdtBrmi1vLdzgdJNntEgzqktVF8LwaCyY+9xIE6TGu/2V+9fJHAwECxjOC1eQbNQdAZ0Tmw==",
+          "requires": {
+            "@aws-sdk/types": "3.296.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-recursion-detection": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.296.0.tgz",
+          "integrity": "sha512-UG7TLDPz9ImQG0uVklHTxE9Us7rTImwN+6el6qZCpoTBuGeXgOkfb0/p8izJyFgY/hMUR4cZqs7IdCDUkxQF3w==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.296.0",
+            "@aws-sdk/types": "3.296.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.296.0.tgz",
+          "integrity": "sha512-Tz3gDZm5viQg7BG5bF9Cg0qbm4+Ur3a7wcGkj1XHQdzGDYR76gxvU0bfnSNUmWRz3kaVNyISyXSOUygG0cbhbw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.296.0",
+            "@aws-sdk/service-error-classification": "3.296.0",
+            "@aws-sdk/types": "3.296.0",
+            "@aws-sdk/util-middleware": "3.296.0",
+            "@aws-sdk/util-retry": "3.296.0",
+            "tslib": "^2.5.0",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/middleware-sdk-sts": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.296.0.tgz",
+          "integrity": "sha512-0EnHtiRzcRcXaF6zEgcRGUtVgX0RqczwlGXjtryHcxiqU/+adqbRuckC7bdMF4Zva6GVPS25XppvGF4M+UzAEw==",
+          "requires": {
+            "@aws-sdk/middleware-signing": "3.296.0",
+            "@aws-sdk/property-provider": "3.296.0",
+            "@aws-sdk/protocol-http": "3.296.0",
+            "@aws-sdk/signature-v4": "3.296.0",
+            "@aws-sdk/types": "3.296.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.296.0.tgz",
+          "integrity": "sha512-xk2PpWAAX758oUTGkGBAncpOr7ddIXisjD2Y2r9DDXuE4JMho2x6zcrVSiYsGIQ6MHZ9XNJKBVDiK9PA4iQWGQ==",
+          "requires": {
+            "@aws-sdk/types": "3.296.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.296.0.tgz",
+          "integrity": "sha512-wyiG+WPDvugGTIPpKchGOdvvpcMZEN2IfP6iK//QAqGXsC6rDm5+SNZ3+elvduZjPUdVA06W0CcFYBAkVz8D7Q==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.296.0",
+            "@aws-sdk/protocol-http": "3.296.0",
+            "@aws-sdk/signature-v4": "3.296.0",
+            "@aws-sdk/types": "3.296.0",
+            "@aws-sdk/util-middleware": "3.296.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.296.0.tgz",
+          "integrity": "sha512-Rgo7/mdk9tt4qa9+pzG3AoGNhuj7NmnF5H+3DoPm75h58BYP8hKbKobdPGgI2rZLPtO3PGgmyw/4K4tQJPIZ8g==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.296.0.tgz",
+          "integrity": "sha512-L7jacxSt6gxX1gD3tQtfwHqBDk5rT2wWD3rxBa6rs7f81b9ObgY/sPT2IgRT7JNCVzvKLYFxJaTklDj65mY1SQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.296.0",
+            "@aws-sdk/types": "3.296.0",
+            "@aws-sdk/util-endpoints": "3.296.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.296.0.tgz",
+          "integrity": "sha512-S/tYcuw9ACOWRmRe5oUkmutQ+TApjVs0yDl504DKs74f3p4kRgI/MGWkBiR3mcfThHaxu81z0gkRL2qfW2SDwg==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.296.0",
+            "@aws-sdk/shared-ini-file-loader": "3.296.0",
+            "@aws-sdk/types": "3.296.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.296.0.tgz",
+          "integrity": "sha512-D15jjPqYSNhEq58BwkmIpD3VwqG4bL5acAaNu5wWAI4S4236JlG+nmpi3gEeE25z1KCwtBl7G30fVRgXYJ2CWA==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.296.0",
+            "@aws-sdk/protocol-http": "3.296.0",
+            "@aws-sdk/querystring-builder": "3.296.0",
+            "@aws-sdk/types": "3.296.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.296.0.tgz",
+          "integrity": "sha512-kjczxE9Od5LoAKQOmxVWISJ9oPG3aCsB+2+NdI+k9EJFDXUUdMcVV3Skei5uHGgKLMsI6CZy8ezZx6YxOSLSew==",
+          "requires": {
+            "@aws-sdk/types": "3.296.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.296.0.tgz",
+          "integrity": "sha512-0U1Z/+tpwdRiSToWo1bpdkbTzjbLugTnd02ATjvK4B7zi363SUGlKfoWgV+v7FU/22CIUI1ZIe7XzXvq5rJfjA==",
+          "requires": {
+            "@aws-sdk/types": "3.296.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.296.0.tgz",
+          "integrity": "sha512-+ZrZdTRaVI1R1xKQNrTwuiRoPateUaJ/DNw/myJpTPt+ZRg0H7LKBGaJYwL4pl5l/z1UM/E1fOttSfSW7GHxfw==",
+          "requires": {
+            "@aws-sdk/types": "3.296.0",
+            "@aws-sdk/util-uri-escape": "3.295.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.296.0.tgz",
+          "integrity": "sha512-nLNZKVQfK42euv7101cE5qfg17YCtGcfccx3B5XSAzvyTROR46kwYqbEvYSsWisbZoRhbQc905gB/5E0U5HDIw==",
+          "requires": {
+            "@aws-sdk/types": "3.296.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.296.0.tgz",
+          "integrity": "sha512-YIsWSQ38e1+FqXz3CMrkKS0JD8OLlHf6I72PJhbfegePpQQFqi9R8OREjP5V7UR9Z972yruv4i96ROH6SCtmoA=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.296.0.tgz",
+          "integrity": "sha512-S31VfdiruN2trayoeB7HifsEB+WXhtfECosj90K903rzfyX+Eo+uUoK9O07UotxJ2gB3MBQ7R8pNnZio3Lb66w==",
+          "requires": {
+            "@aws-sdk/types": "3.296.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.296.0.tgz",
+          "integrity": "sha512-NQyJ/FClty4VmF1WoV4rOkbN0Unn0zevzy8iJrYhqxE3Sc7lySM4Btnsd4Iqelm2dR6l+jNRApGgD8NvoGjGig==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.295.0",
+            "@aws-sdk/types": "3.296.0",
+            "@aws-sdk/util-hex-encoding": "3.295.0",
+            "@aws-sdk/util-middleware": "3.296.0",
+            "@aws-sdk/util-uri-escape": "3.295.0",
+            "@aws-sdk/util-utf8": "3.295.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.296.0.tgz",
+          "integrity": "sha512-HEpsLNozGe9XOWouq5A1TFw5KhFodi8tZqYVNEbSpLoRR+EQKf6OCRvKIRkOn7FnnaOasOR1n7S0D51UG6/irw==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.296.0",
+            "@aws-sdk/types": "3.296.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/token-providers": {
+          "version": "3.298.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.298.0.tgz",
+          "integrity": "sha512-hnUDpK2SPLPJj3wAjWLvKhqditGiDr+V7HLtmqoSOFcXpLuIXE2gjmdADrOVB40t38r/oPQeeQIhUjwgm8HNGA==",
+          "requires": {
+            "@aws-sdk/client-sso-oidc": "3.298.0",
+            "@aws-sdk/property-provider": "3.296.0",
+            "@aws-sdk/shared-ini-file-loader": "3.296.0",
+            "@aws-sdk/types": "3.296.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.296.0.tgz",
+          "integrity": "sha512-s0wIac64rrMEo2ioUxP9IarGiiCGmelCspNcoNTPSjGl25QqjhyfQqTeGgS58qJ4fHoQb07qra39930xp1IzJg==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.296.0.tgz",
+          "integrity": "sha512-nBgeGF+ziuDSLz+y8UAl6zL2tXxDwh3wqeXFe9ZcR4YW71BWuh+vEqEsaEMutOrfnJacCrYKTs9TkIOW41cEGg==",
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.296.0",
+            "@aws-sdk/types": "3.296.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-base64": {
+          "version": "3.295.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.295.0.tgz",
+          "integrity": "sha512-z1r40BsBiOTALnzASvLb4qutGwPpL+jH2UKTCV5WJLXZFMzRnpZaRfeZGE8lMJ/i0+jv9H9G1FmVzE8UgB4rhw==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.295.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.295.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.295.0.tgz",
+          "integrity": "sha512-NbG4/RSHV1VueStPRclSo5zRjNUmcDlNAs29sniZF+YaN0+Ad7hEdu/YgJw39shBfUaurz2Wv0pufU3cxE5Tng==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.295.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.295.0.tgz",
+          "integrity": "sha512-dvGf8VBmrT66lM0n6P/h7wnlHS4Atafyivyl8f4TUCMvRdpqryvvrtnX6yYcq3T7VKQmas/2SOlgDvcrhGXaiw==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.295.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.295.0.tgz",
+          "integrity": "sha512-5ezVEITQnrQKn+CU9qfZHgRp2nrrbX0Clmlm9aiNjAEQEPHY33tWl0t6n8h8yU+IpGiNRMWBVC4aSJaE5NA1mA==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.295.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-config-provider": {
+          "version": "3.295.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.295.0.tgz",
+          "integrity": "sha512-/5Dl1aV2yI8YQjqwmg4RTnl/E9NmNsx7HIwBZt+dTcOrM0LMUwczQBFFcLyqCj/qv5y+VsvLoAAA/OiBT7hb3w==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-browser": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.296.0.tgz",
+          "integrity": "sha512-R+nzc0PuTMaOG3LV4FoS5W7oMAqqr8G1IyI+A4Q5iem6YDMF157qV5h6wpIt3A8n9YfjyssLsAT/WPfyv/M79w==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.296.0",
+            "@aws-sdk/types": "3.296.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-node": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.296.0.tgz",
+          "integrity": "sha512-zsIYynqjBE2xlzpJsT3lb5gy06undSgYq9ziId7QaHFagqtrecHI2ZMcu2tBFcONpu9NPj3nqJB+kJUAnBc8sQ==",
+          "requires": {
+            "@aws-sdk/config-resolver": "3.296.0",
+            "@aws-sdk/credential-provider-imds": "3.296.0",
+            "@aws-sdk/node-config-provider": "3.296.0",
+            "@aws-sdk/property-provider": "3.296.0",
+            "@aws-sdk/types": "3.296.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-endpoints": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.296.0.tgz",
+          "integrity": "sha512-YraGGLJepXM6HCTaqEGTFf8RFRBdJ0C6uG5k0kVhiXmYxBkeupn8J07CVp9jfWqcPYWElAnMGVEZKU1OjRo4HQ==",
+          "requires": {
+            "@aws-sdk/types": "3.296.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.295.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.295.0.tgz",
+          "integrity": "sha512-XJcoVo41kHzhe28PBm/rqt5mdCp8R6abwiW9ug1dA6FOoPUO8kBUxDv6xaOmA2hfRvd2ocFfBXaUCBqUowkGcQ==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-middleware": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.296.0.tgz",
+          "integrity": "sha512-MNWU+doVuX+mIehEManP6OP+f08T33qQpHoBqKIeKpn3TjZjMHG7ujACTkJiEOHUrnwTov7h0Sm+3OZwk3kh9w==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-retry": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.296.0.tgz",
+          "integrity": "sha512-0mh7SqOMjuJ4vE423SzA/AfCLM68jykbfpEBkTmfqkpjkeQSW+UXHAUdXsMmfzIneiq7go5Z548F868C3cZnwQ==",
+          "requires": {
+            "@aws-sdk/service-error-classification": "3.296.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.295.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.295.0.tgz",
+          "integrity": "sha512-1H5DcyIoXF8XcPBWf7wzHt0l+TW2EoR8Oq4gsVrPTQkHMTVclC2Yn8EF3gc4arwVBzwLulI9LMBE2L8fexGfTQ==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.296.0.tgz",
+          "integrity": "sha512-MGGG+09VkF0N+8KEht8NNE6Q7bqmddgqLkUbvzSky0y18UPEZyq9LTC4JZtzDDOzf/swgbq2IQ/5wtB81iouog==",
+          "requires": {
+            "@aws-sdk/types": "3.296.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.296.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.296.0.tgz",
+          "integrity": "sha512-AMWac8aIBnaa9nxAEpZ752j29a/UQTViRfR5gnCX38ECBKGfOQMpgYnee5HdlMr4GHJj0WkOzQxBtInW4pV58g==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.296.0",
+            "@aws-sdk/types": "3.296.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-utf8": {
+          "version": "3.295.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.295.0.tgz",
+          "integrity": "sha512-ITN8v3F63ZkA4sdmCtSbS/mhav4F0MEAiXDAUXtMJLNqVtaVcyQST4i9vNmPpIVthAPAtP0QjyF2tq/Di8bxtQ==",
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.295.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
       }
     },
     "@aws-sdk/client-sso": {


### PR DESCRIPTION
**authorization-service** is added

**Import Service** serverless.yaml file has authorizer configuration for the importProductsFile lambda.
 Request to the importProductsFile lambda works only with correct authorization_token being decoded and checked by basicAuthorizer lambda.
 Response has 403 HTTP status if access is denied for this user (invalid authorization_token) and 401 HTTP status if Authorization header is not provided.

Client application is updated to send "Authorization: Basic authorization_token" header on import. Client get authorization_token value from browser localStorage

![image](https://user-images.githubusercontent.com/21066797/228246817-54dc0eb2-a923-494e-9f83-36e34ad2837a.png)

**natalliabelavusava:TEST_PASSWORD**  base64-encoded --> 
bmF0YWxsaWFiZWxhdnVzYXZhOlRFU1RfUEFTU1dPUkQ=

**link to the cloudfront** https://dr56gouy8eq50.cloudfront.net/ 

**Additional task:**
Client application displays alerts for the responses in 401 and 403 HTTP statuses
https://github.com/natallia-belavusava/shop-react-redux-cloudfront/pull/3/commits/34c5811d0bbf684a7e737a40bc76c11fdbe679c3